### PR TITLE
Add support for multiarch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20211220-slim
+FROM --platform=$TARGETPLATFORM debian:bullseye-20211220-slim
 
 ENV LANG=C.UTF-8
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
+docker buildx build \
+--push \
+--tag "$DOCKER_REPO":"$DOCKER_TAG" \
+--platform linux/amd64,linux/arm64/v8 .
+

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# This hook is empty because the image was pushed to the registry in the build hook
+


### PR DESCRIPTION
# Description

**What?**

This pull request adds native support for the ARM architecture.

**Why?**

Course builds are extremely slow on ARM based M1 Macs. Based on testing, the native ARM image speeds up the course build on the Y2 programming course from 156 seconds to 22 seconds.

**How?**

A custom build hook is used to build the image for amd64 and arm64.
No other changes are needed elsewhere, for example in the course's ``docker-compile.sh`` for the speed up. The correct image is automatically downloaded from Docker Hub based on the user's platform.

Test images in my Docker Hub: https://hub.docker.com/repository/docker/ihalaij1/compile-rst/tags

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested on my own Docker Hub account that automated builds work and correctly output images for amd64 and arm64 platforms.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature