### PR TITLE
Add regex pip package for recursive patterns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -qqy && DEBIAN_FRONTEND=noninteractive apt-get install -qqy -
     "sphinx~=4.3.2" \
     Unidecode \
     "PyYAML~=6.0" \
+    regex \
   && rm -rf /root/.cache
 
 COPY dummy_git.sh /usr/local/bin/git


### PR DESCRIPTION
# Description

**What?**

The standard re module in Python does not support
recursive regular expression patterns, which are needed for the new 'structured-randomized' checkbox question option implemented in apluslms/a-plus-rst-tools#169

Part of apluslms/mooc-grader#120